### PR TITLE
Order+9102

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 # 9.0.2 required for static linking matching GHC version provided by lts-19.33
-FROM utdemir/ghc-musl:v25-ghc902 AS builder
-
-RUN ghcup install stack
+FROM docker.io/benz0li/ghc-musl:9.10.2 AS builder
 WORKDIR /opt/app/
 COPY feedfarer.cabal stack.yaml .
 
 # Dependencies for caching
-RUN stack --resolver lts-19.33 build \
+RUN stack --resolver nightly-2025-06-16 build \
   --no-install-ghc \
   --system-ghc \
   --no-library-profiling \
@@ -15,7 +13,7 @@ RUN stack --resolver lts-19.33 build \
 # Build main
 COPY . .
 
-RUN stack --resolver lts-19.33 install \
+RUN stack --resolver nightly-2025-06-16 install \
   --no-install-ghc \
   --system-ghc \
   --local-bin-path . \

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM haskell:9.0.2
+FROM docker.io/benz0li/ghc-musl:9.10.2
 # Version from build arg
 ARG app_version
 ENV APP_VERSION=$app_version
@@ -6,7 +6,7 @@ ENV APP_VERSION=$app_version
 # Dependencies for caching
 WORKDIR /opt/app
 COPY feedfarer.cabal stack.yaml .
-RUN stack --resolver lts-19.33 test \
+RUN stack --resolver nightly-2025-06-16 test \
   --install-ghc \
   --no-library-profiling \
   --fast \
@@ -17,4 +17,4 @@ COPY . .
 COPY /static /var/www/feedfarer-webui
 
 # Build and run tests
-CMD ["stack", "--resolver", "lts-19.33", "test", "--fast"]
+CMD ["stack", "--resolver", "nightly-2025-06-16", "test", "--fast"]

--- a/feedfarer.cabal
+++ b/feedfarer.cabal
@@ -5,13 +5,13 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           feedfarer
-version:        1.2
+version:        2.5
 description:    Please see the README on GitHub at <https://github.com/githubuser/feedfarer#readme>
 homepage:       https://github.com/githubuser/feedfarer#readme
 bug-reports:    https://github.com/githubuser/feedfarer/issues
 author:         Adrien Glauser
 maintainer:     mrnycticorax@gmail.com
-copyright:      2021 Adrien Glauser
+copyright:      2021, 2025 Adrien Glauser
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/feedfarer.cabal
+++ b/feedfarer.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.38.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -55,7 +55,7 @@ library
       OverloadedStrings
       StrictData
       BangPatterns
-  ghc-options: -Wall
+  ghc-options: -Wall -Wno-x-partial -Wno-unrecognised-warning-flags
   build-depends:
       aeson
     , async
@@ -154,7 +154,7 @@ test-suite feedfarer-test
       OverloadedStrings
       StrictData
       BangPatterns
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wno-x-partial -Wno-unrecognised-warning-flags
   build-depends:
       aeson
     , async

--- a/flake.lock
+++ b/flake.lock
@@ -18,21 +18,38 @@
         "type": "github"
       }
     },
+    "haskell-updates": {
+      "locked": {
+        "lastModified": 1750551965,
+        "narHash": "sha256-Qz7kvBM/fDPpbR9jc7Bu72ACigv60/3SakreuqPyQuk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9f581af8b95f360239dc76031ee88da83c05aff8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "haskell-updates",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703013332,
-        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
+        "lastModified": 1750365781,
+        "narHash": "sha256-XE/lFNhz5lsriMm/yjXkvSZz5DfvKJLUjsS6pP8EC50=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/54aac082a4d9.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/08f2208.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/54aac082a4d9.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/08f2208.tar.gz"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "haskell-updates": "haskell-updates",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
             pkgs.openssl
             pkgs.zlib
           ];
-          NIX_LD = pkgs.lib.fileContents "${pkgs.stdenv.cc}/nix-support/dynamic-linker";
+          NIX_LD = builtins.readFile "${pkgs.stdenv.cc}/nix-support/dynamic-linker";
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -1,22 +1,31 @@
 {
   inputs = {
-    nixpkgs.url = "https://github.com/NixOS/nixpkgs/archive/54aac082a4d9.tar.gz";
+    nixpkgs.url = "https://github.com/NixOS/nixpkgs/archive/08f2208.tar.gz";
     flake-utils.url = "github:numtide/flake-utils";
+    haskell-updates.url = "github:NixOS/nixpkgs/haskell-updates";
   };
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, haskell-updates, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+                (final: prev: {
+                    haskell-language-server =
+                        haskell-updates.legacyPackages.${system}.haskell.packages.ghc9102.haskell-language-server;
+                })
+            ];
+        };
       in
       {
         devShell = pkgs.mkShell {
-          buildInputs = [
-            pkgs.stack
-            pkgs.ghc
-            pkgs.haskell-language-server
-            pkgs.haskellPackages.fourmolu
-            pkgs.haskellPackages.hoogle
-            pkgs.zlib
+          buildInputs = with pkgs; [
+            stack
+            haskell.compiler.ghc9102
+            haskell-language-server
+            haskellPackages.fourmolu
+            haskellPackages.hoogle
+            zlib
           ];
           NIX_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
             pkgs.stdenv.cc.cc

--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,8 @@ library:
   source-dirs: src
   ghc-options:
   - -Wall
+  - -Wno-x-partial
+  - -Wno-unrecognised-warning-flags
 
 executables:
   feedfarer-exe:
@@ -79,6 +81,9 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    - -Wno-x-partial
+    - -Wno-unrecognised-warning-flags
+
     dependencies:
     - feedfarer
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,10 +1,10 @@
 name:                feedfarer
-version:             1.2
+version:             2.5
 github:              "githubuser/feedfarer"
 license:             BSD3
 author:              "Adrien Glauser"
 maintainer:          "mrnycticorax@gmail.com"
-copyright:           "2021 Adrien Glauser"
+copyright:           "2021, 2025 Adrien Glauser"
 
 extra-source-files:
 - README.md

--- a/src/Chats.hs
+++ b/src/Chats.hs
@@ -5,7 +5,6 @@ module Chats (withChat, getChats) where
 
 import Control.Monad.Reader
 import qualified Data.HashMap.Strict as HMS
-import Data.List (foldl')
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as S
 import qualified Data.Text as T

--- a/src/Digests.hs
+++ b/src/Digests.hs
@@ -6,7 +6,6 @@ import Control.Concurrent.Async
 import Control.Monad
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.RWS (MonadReader (..))
-import Data.Foldable (foldl')
 import qualified Data.HashMap.Strict as HMS
 import qualified Data.Set as S
 import qualified Data.Text as T

--- a/src/Feeds.hs
+++ b/src/Feeds.hs
@@ -4,7 +4,6 @@ module Feeds (buildFeed, eitherUrlScheme, getFeedFromUrlScheme, rebuildFeed) whe
 
 import Control.Exception (SomeException (SomeException))
 import Control.Monad.Reader
-import Data.Foldable (Foldable (..))
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import Data.Time (getCurrentTime)

--- a/src/Markdown.hs
+++ b/src/Markdown.hs
@@ -3,7 +3,6 @@
 
 module Markdown (parse, render, parsing) where
 
-import Data.Foldable
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 

--- a/src/Mongo.hs
+++ b/src/Mongo.hs
@@ -12,8 +12,8 @@ import Crypto.Hash (SHA256 (SHA256), hashWith)
 import qualified Data.ByteString.Char8 as B
 import Data.Functor ((<&>))
 import qualified Data.HashMap.Strict as HMS
-import qualified Data.List as List
 import qualified Data.IntMap.Strict as M
+import qualified Data.List as List
 import Data.Maybe (fromJust, fromMaybe)
 import Data.Ord
 import qualified Data.Set as S
@@ -478,18 +478,17 @@ bsonToFeed doc =
 {- Chats, Settings -}
 
 documentToMap :: [Field] -> M.IntMap T.Text
-documentToMap doc = 
+documentToMap doc =
   let elems = map (\kv -> (toInt $ label kv, toText $ value kv)) doc
-  in  M.fromList elems 
-  where 
-    toText x = T.pack . show $ x
-    toInt x = case readMaybe (T.unpack x) :: Maybe Int of
-      Just n -> n
-      Nothing -> undefined
+   in M.fromList elems
+ where
+  toText x = T.pack . show $ x
+  toInt x = case readMaybe (T.unpack x) :: Maybe Int of
+    Just n -> n
+    Nothing -> throw $ userError ("Unable to read this number: " ++ show x)
 
 mapToDocument :: M.IntMap T.Text -> Document
-mapToDocument m = [ T.pack (show k) := String v | (k, v) <- M.toList m ]
-
+mapToDocument m = [T.pack (show k) := String v | (k, v) <- M.toList m]
 
 bsonToChat :: Document -> SubChat
 bsonToChat doc =

--- a/src/Replies.hs
+++ b/src/Replies.hs
@@ -13,7 +13,7 @@ import Data.Time (UTCTime (utctDay), defaultTimeLocale, formatTime, toGregorian)
 import Network.URI.Encode (encodeText)
 import TgramOutJson (TgRequestMethod (TgDeleteMessage, TgEditMessage, TgGetChat, TgGetChatAdministrators, TgPinChatMessage, TgSendMessage))
 import Types
-import Utils (nomDiffToReadable, sortFeedsOnSettings, renderAvgInterval, utcToYmd, utcToYmdHMS)
+import Utils (nomDiffToReadable, renderAvgInterval, sortFeedsOnSettings, utcToYmd, utcToYmdHMS)
 
 escapeWhere :: T.Text -> [T.Text] -> T.Text
 escapeWhere txt suspects =

--- a/src/Replies.hs
+++ b/src/Replies.hs
@@ -4,7 +4,6 @@
 
 module Replies (defaultReply, mkdSingles, mkdDoubles, renderCmds, render, Reply (..), mkReply, Replies (..), mkViewUrl, mkDigestUrl) where
 
-import Data.Foldable (foldl')
 import qualified Data.HashMap.Strict as HMS
 import Data.List (sortOn)
 import Data.Ord (Down (Down))

--- a/src/Replies.hs
+++ b/src/Replies.hs
@@ -411,6 +411,7 @@ items - <optional: channel_id> <# or url> display all the items fetched from the
 list - <optional: channel_id> list all the feeds this chat or that channel is subscribed to
 link - <chat_id or channel_id> allow the current chat to get the same permissions as the target chat or channel when accessing feeds data.
 migrate - <optional: chat_id of the origin> <chat_id of the destination> migrate this chat's settings, or the settings of the channel at the origin, to the destination
+order - <1 2 3 ...> Sort feeds in digests and in reply to /list according after reindexing them with <1 2 3 ...>
 pause - <optional: channel_id> stop posting updates to this chat or to that channel
 purge - <optional: channel_id> delete all data about this chat or that channel
 reset - <optional: channel_id> set this chat's (or that channels') settings to their default values

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -2,7 +2,6 @@
 
 module Settings (parseSettings) where
 
-import Data.Foldable (foldl')
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Data.Time

--- a/src/TgActions.hs
+++ b/src/TgActions.hs
@@ -11,7 +11,7 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Reader (MonadReader, ask)
 import Data.Functor
 import qualified Data.HashMap.Strict as HMS
-import Data.List (find, foldl', sort)
+import Data.List (find, sort)
 import Data.Maybe (fromJust)
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -74,7 +74,7 @@ import Types (
   UserAction (..),
   runApp,
  )
-import Utils (areAllInts, maybeUserIdx, partitionEither, reindex, toFeedRef, tooManySubs, unFeedRefs)
+import Utils (areAllInts, maybeUserIdx, partitionEither, toFeedRef, tooManySubs, unFeedRefs)
 
 isUserAdmin :: (TgReqM m) => BotToken -> UserId -> ChatId -> m (Either TgEvalError Bool)
 isUserAdmin tok uid cid =

--- a/src/TgActions.hs
+++ b/src/TgActions.hs
@@ -9,9 +9,10 @@ import Control.Concurrent.Async (concurrently, mapConcurrently, mapConcurrently_
 import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Reader (MonadReader, ask)
-import Data.Functor
+import Data.Functor (void, (<&>))
 import qualified Data.HashMap.Strict as HMS
 import Data.List (find, sort)
+import qualified Data.Map.Strict as M
 import Data.Maybe (fromJust)
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -59,7 +60,8 @@ import Types (
   ),
   Reply (EditReply, ServiceReply),
   ServerConfig (alert_chat, bot_token),
-  SettingsUpdater (Parsed),
+  Settings (settings_digest_feeds_order),
+  SettingsUpdater (Immediate, Parsed),
   SubChat (sub_feeds_links, sub_linked_to, sub_settings),
   TgEvalError (
     BadRef,
@@ -551,6 +553,28 @@ evalTgAct uid (Migrate to) cid = do
         `T.append` (T.pack . show $ to)
   onErr err = pure . Right . ServiceReply $ render err
 evalTgAct uid (MigrateChannel fr to) _ = evalTgAct uid (Migrate to) fr
+evalTgAct uid (Order ns) cid =
+  ask >>= \env ->
+    let tok = bot_token . tg_config $ env
+     in isUserAdmin tok uid cid >>= \case
+          Left err -> pure . Left $ err
+          Right verdict ->
+            if not verdict
+              then exitNotAuth uid
+              else
+                HMS.lookup cid <$> getChats >>= \case
+                  Nothing -> undefined
+                  Just c ->
+                    let prev_settings = sub_settings c
+                        new_order =
+                          let reordered = M.fromList $ zip (S.toList $ sub_feeds_links c) ns
+                           in Just reordered
+                        new_settings = Immediate $ prev_settings{settings_digest_feeds_order = new_order}
+                     in withChat (SetChatSettings new_settings) (Just uid) cid >>= \case
+                          Left err -> pure . Right . ServiceReply . render $ err
+                          Right _ -> pure . Right . ServiceReply $ succeeded
+ where
+  succeeded = "Re-ordered feeds in digests. Use /list to view the new order."
 evalTgAct uid (Pause pause_or_resume) cid =
   ask >>= \env ->
     let tok = bot_token . tg_config $ env

--- a/src/TgActions.hs
+++ b/src/TgActions.hs
@@ -12,7 +12,7 @@ import Control.Monad.Reader (MonadReader, ask)
 import Data.Functor (void, (<&>))
 import qualified Data.HashMap.Strict as HMS
 import Data.List (find, sort)
-import qualified Data.Map.Strict as M
+import qualified Data.IntMap.Strict as M
 import Data.Maybe (fromJust)
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -567,7 +567,7 @@ evalTgAct uid (Order ns) cid =
                   Just c ->
                     let prev_settings = sub_settings c
                         new_order =
-                          let reordered = M.fromList $ zip (S.toList $ sub_feeds_links c) ns
+                          let reordered = M.fromList $ zip ns (S.toList $ sub_feeds_links c)
                            in Just reordered
                         new_settings = Immediate $ prev_settings{settings_digest_feeds_order = new_order}
                      in withChat (SetChatSettings new_settings) (Just uid) cid >>= \case

--- a/src/TgActions.hs
+++ b/src/TgActions.hs
@@ -11,8 +11,8 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Reader (MonadReader, ask)
 import Data.Functor (void, (<&>))
 import qualified Data.HashMap.Strict as HMS
-import Data.List (find, sort)
 import qualified Data.IntMap.Strict as M
+import Data.List (find, sort)
 import Data.Maybe (fromJust)
 import qualified Data.Set as S
 import qualified Data.Text as T

--- a/src/TgActions.hs
+++ b/src/TgActions.hs
@@ -76,7 +76,7 @@ import Types (
   UserAction (..),
   runApp,
  )
-import Utils (areAllInts, maybeUserIdx, partitionEither, toFeedRef, tooManySubs, unFeedRefs)
+import Utils (mapToInts, maybeUserIdx, partitionEither, toFeedRef, tooManySubs, unFeedRefs)
 
 isUserAdmin :: (TgReqM m) => BotToken -> UserId -> ChatId -> m (Either TgEvalError Bool)
 isUserAdmin tok uid cid =
@@ -197,7 +197,7 @@ interpretCmd contents
   | cmd == "/order" =
       if null args
         then Left . InterpreterErr $ "/order needs a sequence of numbers to use to re-order feeds list."
-        else case areAllInts args of
+        else case mapToInts args of
           Left _ -> Left . InterpreterErr $ "All words following '/order' must be integers."
           Right ns -> Right $ Order ns
   | cmd == "/pause" || cmd == "/p" =

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -268,7 +268,6 @@ data ParsingSettings
   | PDisableWebview Bool
   | PPagination Bool
   | PForwardToAdmins Bool
-  | POrder Int
   | PPaused Bool
   | PPin Bool
   | PDigestCollapse Int

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -6,7 +6,7 @@
 module Types where
 
 import Control.Concurrent (Chan)
-import Control.Monad.List (foldM)
+import Control.Monad (foldM)
 import Control.Monad.Reader (MonadIO, MonadReader, ReaderT (runReaderT))
 import Data.Aeson
 import qualified Data.Aeson.KeyMap as A
@@ -293,6 +293,7 @@ data UserAction
   | ListSubsChannel ChatId
   | Migrate ChatId
   | MigrateChannel ChatId ChatId
+  | OrderFeeds [Int]
   | Pause Bool
   | PauseChannel ChatId Bool
   | Purge

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -14,7 +14,7 @@ import Data.Aeson.TH
 import Data.Aeson.Types
 import qualified Data.HashMap.Strict as HMS
 import Data.IORef (IORef)
-import qualified Data.Map.Strict as M
+import qualified Data.IntMap.Strict as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -136,7 +136,7 @@ data Settings = Settings
   , settings_digest_title :: T.Text
   , settings_disable_web_view :: Bool
   , settings_forward_to_admins :: Bool
-  , settings_digest_feeds_order :: Maybe (M.Map FeedLink Int)
+  , settings_digest_feeds_order :: Maybe (M.IntMap FeedLink)
   , settings_pagination :: Bool
   , settings_paused :: Bool
   , settings_pin :: Bool

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -14,6 +14,7 @@ import Data.Aeson.TH
 import Data.Aeson.Types
 import qualified Data.HashMap.Strict as HMS
 import Data.IORef (IORef)
+import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -135,6 +136,7 @@ data Settings = Settings
   , settings_digest_title :: T.Text
   , settings_disable_web_view :: Bool
   , settings_forward_to_admins :: Bool
+  , settings_digest_feeds_order :: Maybe (M.Map FeedLink Int)
   , settings_pagination :: Bool
   , settings_paused :: Bool
   , settings_pin :: Bool
@@ -190,6 +192,7 @@ instance FromJSON Settings where
           <*> o
             .:? "settings_forward_to_admins"
             .!= False
+          <*> o .:? "settings_digest_feeds_order"
           <*> o
             .:? "settings_pagination"
             .!= True
@@ -265,6 +268,7 @@ data ParsingSettings
   | PDisableWebview Bool
   | PPagination Bool
   | PForwardToAdmins Bool
+  | POrder Int
   | PPaused Bool
   | PPin Bool
   | PDigestCollapse Int

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -293,7 +293,7 @@ data UserAction
   | ListSubsChannel ChatId
   | Migrate ChatId
   | MigrateChannel ChatId ChatId
-  | OrderFeeds [Int]
+  | Order [Int]
   | Pause Bool
   | PauseChannel ChatId Bool
   | Purge

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -221,6 +221,7 @@ defaultChatSettings =
     , settings_digest_title = "A new digest is available"
     , settings_paused = False
     , settings_disable_web_view = False
+    , settings_digest_feeds_order = Nothing
     , settings_pagination = False
     , settings_pin = False
     , settings_share_link = True

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -318,18 +318,15 @@ mapToInts = foldr step (Right [])
       Just n -> (n :) <$> acc
 
 sortFeedsOnSettings :: Settings -> [Feed] -> [Feed]
-sortFeedsOnSettings s fs =
-  let orig = map (\f -> (f_link f, f)) fs
-      orig_map = Ms.fromList orig
-      feeds_intmap = Ms.fromList $ zip (map f_link fs) [1 .. length orig]
-   in case settings_digest_feeds_order s of
-        Nothing -> fs
-        Just pref_map ->
-          let pref_map_inv = invertIntMap pref_map
-              rekeyed = Ms.mapWithKey (\link idx -> case Ms.lookup link pref_map_inv of Nothing -> idx; Just idx' -> idx') feeds_intmap
-              reordered = sortOn snd $ Ms.toList rekeyed
-              refilled = map (\(link, _) -> orig_map Ms.! link) reordered
-           in refilled
-
-invertIntMap :: M.IntMap T.Text -> Ms.Map T.Text Int
-invertIntMap m = M.foldrWithKey (\k v acc -> Ms.insert v k acc) Ms.empty m
+sortFeedsOnSettings s fs = case settings_digest_feeds_order s of
+  Nothing -> fs
+  Just pref ->
+    let inv_pref = invertIntMap pref
+        orig = map (\f -> (f_link f, f)) fs
+        src = Ms.fromList $ zip (map f_link fs) [1 .. length orig]
+        rekeyed = Ms.intersection (Ms.union inv_pref src) src
+        sorted = sortOn snd $ Ms.toList rekeyed
+        m_orig = Ms.fromList orig
+     in map (\(link, _) -> m_orig Ms.! link) sorted
+   where
+    invertIntMap m = M.foldrWithKey (\k v acc -> Ms.insert v k acc) Ms.empty m

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -308,8 +308,8 @@ sliceIfAboveTelegramMax msg
   | T.length msg <= 4096 = pure msg
   | otherwise = removeAllEmptyLines <$> sliceOnN msg 4096
 
-areAllInts :: [T.Text] -> Either T.Text [Int]
-areAllInts = foldr step (Right [])
+mapToInts :: [T.Text] -> Either T.Text [Int]
+mapToInts = foldr step (Right [])
  where
   step t acc =
     case readMaybe (T.unpack t) of
@@ -322,8 +322,8 @@ sortFeedsOnSettings settings feeds =
       prev_intmap = M.fromList . zip [1 .. length feeds] $ feeds
       merged new_intmap = mergeMatching f_link new_intmap prev_intmap
    in case sort_settings of
-    Nothing -> feeds
-    Just m -> M.elems $ merged m
+        Nothing -> feeds
+        Just m -> M.elems $ merged m
 
 mergeMatching :: (Eq a) => (b -> a) -> M.IntMap a -> M.IntMap b -> M.IntMap b
 mergeMatching f m1 m2 =

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -314,10 +314,3 @@ areAllInts = foldr step (Right [])
     case readMaybe (T.unpack t) of
       Nothing -> Left t
       Just n -> (n :) <$> acc
-
-reindex :: (Ord b) => [a] -> [b] -> [a]
-reindex a b =
-  map snd
-    . sortOn fst
-    . zip b
-    $ a

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -305,3 +305,12 @@ sliceIfAboveTelegramMax :: T.Text -> [T.Text]
 sliceIfAboveTelegramMax msg
   | T.length msg <= 4096 = pure msg
   | otherwise = removeAllEmptyLines <$> sliceOnN msg 4096
+
+areAllInts :: [T.Text] -> Either T.Text [Int]
+areAllInts ts =
+  let (err, ok) = foldr step (mempty, []) ts
+   in if err == mempty then Left err else Right ok
+ where
+  step val (err, ok) = case readMaybe . T.unpack $ val :: Maybe Int of
+    Nothing -> (val, ok)
+    Just n -> (err, n : ok)

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -2,7 +2,7 @@ module Utils where
 
 import qualified Data.HashMap.Strict as HMS
 import Data.Int (Int64)
-import Data.List (foldl', sort, sortOn)
+import Data.List (sort, sortOn)
 import Data.Ord (Down (Down))
 import qualified Data.Set as S
 import qualified Data.Text as T

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -2,6 +2,7 @@ module Utils where
 
 import qualified Data.HashMap.Strict as HMS
 import Data.Int (Int64)
+import qualified Data.IntMap as M
 import Data.List (sort, sortOn)
 import Data.Ord (Down (Down))
 import qualified Data.Set as S
@@ -314,3 +315,21 @@ areAllInts = foldr step (Right [])
     case readMaybe (T.unpack t) of
       Nothing -> Left t
       Just n -> (n :) <$> acc
+
+sortFeedsOnSettings :: Settings -> [Feed] -> [Feed]
+sortFeedsOnSettings settings feeds =
+  let sort_settings = settings_digest_feeds_order settings
+      prev_intmap = M.fromList . zip [1 .. length feeds] $ feeds
+      merged new_intmap = mergeMatching f_link new_intmap prev_intmap
+   in case sort_settings of
+    Nothing -> feeds
+    Just m -> M.elems $ merged m
+
+mergeMatching :: (Eq a) => (b -> a) -> M.IntMap a -> M.IntMap b -> M.IntMap b
+mergeMatching f m1 m2 =
+  M.mergeWithKey
+    (\_ a b -> if a == f b then Just b else Nothing)
+    (const M.empty)
+    (const M.empty)
+    m1
+    m2

--- a/src/Web.hs
+++ b/src/Web.hs
@@ -3,7 +3,8 @@
 module Web where
 
 import Chats (getChats, withChat)
-import Control.Monad.Reader (MonadIO (liftIO), forM_)
+import Control.Monad (forM_)
+import Control.Monad.Reader (MonadIO (liftIO))
 import Data.Foldable (Foldable (foldl'))
 import Data.Functor ((<&>))
 import qualified Data.HashMap.Strict as HMS

--- a/src/Web.hs
+++ b/src/Web.hs
@@ -5,7 +5,6 @@ module Web where
 import Chats (getChats, withChat)
 import Control.Monad (forM_)
 import Control.Monad.Reader (MonadIO (liftIO))
-import Data.Foldable (Foldable (foldl'))
 import Data.Functor ((<&>))
 import qualified Data.HashMap.Strict as HMS
 import qualified Data.HashSet as S

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.25
+resolver: nightly-2025-06-16
 packages:
   - .
 extra-deps: []
@@ -8,3 +8,4 @@ nix:
 
 system-ghc: true
 install-ghc: false
+notify-if-nix-on-path: false

--- a/test/RepliesSpec.hs
+++ b/test/RepliesSpec.hs
@@ -2,18 +2,20 @@
 
 module RepliesSpec where
 
-import qualified Data.Map.Strict as M
+import qualified Data.IntMap.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Data.Time.Clock (getCurrentTime)
+import Hooks (withHooks)
 import Replies (mkReply)
 import Test.Hspec
 import Types
+import Utils (sortFeedsOnSettings)
 
 spec :: Spec
-spec = go
+spec = go1
  where
-  go =
+  go1 =
     let desc = describe "Validates reply from settings x notification payload"
         as = it "makes sure that no_collapse is respected"
         target = do

--- a/test/RepliesSpec.hs
+++ b/test/RepliesSpec.hs
@@ -2,6 +2,7 @@
 
 module RepliesSpec where
 
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Data.Time.Clock (getCurrentTime)
@@ -20,7 +21,7 @@ spec = go
           let protected = "https://specially.protected.org"
               unprotected = "https://notspecially.andunprotected.org"
               matches = WordMatches S.empty S.empty S.empty
-              settings = Settings (Just 3) (DigestInterval Nothing Nothing) 10 Nothing "title" False False False False False False matches (S.singleton protected)
+              settings = Settings (Just 3) (DigestInterval Nothing Nothing) 10 Nothing "title" False False Nothing False False False False matches (S.singleton protected)
               protected_items = map (\i -> let n = show i in Item ("protected_title" `T.append` T.pack n) "protected_desc" "protected_link" protected now) [1 .. 10]
               unprotected_items = map (\i -> let n = show i in Item ("unprotected_title" `T.append` T.pack n) "unprotected_desc" "unprotected_link" unprotected now) [1 .. 10]
               feeds =

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -137,5 +137,5 @@ spec = sequence_ [go, go1, go2, go3, go4, go5, go6, go7, go8]
                     two = Feed Rss "desc" "title" url2 items2 Nothing Nothing
                  in [one, two]
               reordered_feeds = sortFeedsOnSettings settings feeds
-          reordered_feeds `shouldSatisfy` (\feeds -> (f_link . head $ feeds) == url2)
+          reordered_feeds `shouldSatisfy` (\fs -> (f_link . head $ fs) == url2)
      in desc $ as target

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -4,6 +4,7 @@ module UtilsSpec where
 
 import qualified Data.HashMap.Strict as HMS
 import Data.Int (Int64)
+import qualified Data.IntMap as M
 import Data.Maybe
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -11,7 +12,7 @@ import Data.Time (UTCTime, diffUTCTime, getCurrentTime)
 import Digests
 import Test.Hspec
 import TgramOutJson (ChatId)
-import Types (DigestInterval (DigestInterval), Feed (Feed, f_items, f_link), FeedType (Rss), Item (Item, i_feed_link, i_link, i_title), Settings (settings_word_matches), SubChat (SubChat), WordMatches (WordMatches), i_desc)
+import Types (DigestInterval (DigestInterval), Feed (Feed, f_items, f_link), FeedType (Rss), Item (Item, i_feed_link, i_link, i_title), Settings (Settings, settings_word_matches), SubChat (SubChat), WordMatches (WordMatches), i_desc)
 import Utils (
   defaultChatSettings,
   findNextTime,
@@ -20,6 +21,7 @@ import Utils (
   mbTime,
   partitionEither,
   scanTimeSlices,
+  sortFeedsOnSettings,
  )
 
 mockFeedsChats :: UTCTime -> ([T.Text], HMS.HashMap T.Text Feed, HMS.HashMap ChatId SubChat)
@@ -47,7 +49,7 @@ mockFeedsChats now =
    in (fl, feeds, chats)
 
 spec :: Spec
-spec = sequence_ [go, go1, go2, go3, go4, go5, go6, go7]
+spec = sequence_ [go, go1, go2, go3, go4, go5, go6, go7, go8]
  where
   go =
     let desc = describe "partitionEither"
@@ -116,4 +118,24 @@ spec = sequence_ [go, go1, go2, go3, go4, go5, go6, go7]
               interval = DigestInterval (Just 172800) (Just [(0, 1)])
               t1 = findNextTime t0 interval
           t1 `shouldSatisfy` (\t -> diffUTCTime t t0 >= 172800)
+     in desc $ as target
+  go8 =
+    let desc = describe "Validates reply from settings x notification payload with preferred order"
+        as = it "makes sure that preferred order is respected"
+        target = do
+          now <- getCurrentTime
+          let url1 = "https://specially.protected.org"
+              url2 = "https://notspecially.andunprotected.org"
+              matches = WordMatches S.empty S.empty S.empty
+              scope = S.empty
+              preferred_order = Just $ M.fromList [(1, url2), (2, url1)]
+              settings = Settings (Just 3) (DigestInterval Nothing Nothing) 10 Nothing "title" False False preferred_order False False False False matches scope
+              items1 = map (\i -> let n = show i in Item ("protected_title" `T.append` T.pack n) "protected_desc" "protected_link" url1 now) [1 .. 10]
+              items2 = map (\i -> let n = show i in Item ("unprotected_title" `T.append` T.pack n) "unprotected_desc" "unprotected_link" url2 now) [1 .. 10]
+              feeds =
+                let one = Feed Rss "desc" "title" url1 items1 Nothing Nothing
+                    two = Feed Rss "desc" "title" url2 items2 Nothing Nothing
+                 in [one, two]
+              reordered_feeds = sortFeedsOnSettings settings feeds
+          reordered_feeds `shouldSatisfy` (\feeds -> (f_link . head $ feeds) == url2)
      in desc $ as target


### PR DESCRIPTION
1. Added `/order` to reindex feeds & items when rendering according to user preferences
2. Upgraded code base and build config to make use of GHC 9.10.2
NB: the implemention is safe against partial or outdated reindexing. That it will apply only to feeds with an up-to-date reference and index in the settings.