### PR TITLE
Better docker cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ name: Tests
 on:
   pull_request:
     branches: [master]
-  push:
-    branches: [master]
   workflow_dispatch:
 
 concurrency:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,18 @@
-# 9.0.2 required for static linking matching GHC version provided by lts-19.33
-FROM docker.io/benz0li/ghc-musl:9.10.2 AS builder
-WORKDIR /opt/app/
-COPY feedfarer.cabal stack.yaml .
-
-# Dependencies for caching
-RUN stack --resolver nightly-2025-06-16 build \
-  --no-install-ghc \
-  --system-ghc \
-  --no-library-profiling \
-  --only-dependencies
-
-# Build main
+FROM ghcr.io/why-not-try-calmer/feedo-deps AS deps
 COPY . .
-
 RUN stack --resolver nightly-2025-06-16 install \
   --no-install-ghc \
   --system-ghc \
   --local-bin-path . \
   --flag feedfarer:static
 
-FROM alpine:latest AS runner
+FROM alpine:latest
 
 # Version from build arg
 ARG app_version
 ENV APP_VERSION=$app_version
 
 WORKDIR /opt/app/
-COPY --from=builder /opt/app/feedfarer-exe .
+COPY --from=deps /opt/app/feedfarer-exe .
 
 CMD ["./feedfarer-exe"]

--- a/Dockerfile-deps
+++ b/Dockerfile-deps
@@ -1,0 +1,11 @@
+# 9.0.2 required for static linking matching GHC version provided by lts-19.33
+FROM docker.io/benz0li/ghc-musl:9.10.2 AS builder
+WORKDIR /opt/app/
+COPY feedfarer.cabal stack.yaml .
+
+# Dependencies for caching
+RUN stack --resolver nightly-2025-06-16 build \
+  --no-install-ghc \
+  --system-ghc \
+  --no-library-profiling \
+  --only-dependencies

--- a/Dockerfile-deps
+++ b/Dockerfile-deps
@@ -1,9 +1,7 @@
-# 9.0.2 required for static linking matching GHC version provided by lts-19.33
-FROM docker.io/benz0li/ghc-musl:9.10.2 AS builder
+# Only dependencies to speed up build times
+FROM docker.io/benz0li/ghc-musl:9.10.2
 WORKDIR /opt/app/
 COPY feedfarer.cabal stack.yaml .
-
-# Dependencies for caching
 RUN stack --resolver nightly-2025-06-16 build \
   --no-install-ghc \
   --system-ghc \

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,19 +1,10 @@
-FROM docker.io/benz0li/ghc-musl:9.10.2
+FROM ghcr.io/why-not-try-calmer/feedo-deps
+COPY . . 
+COPY /static /var/www/feedfarer-webui
+
 # Version from build arg
 ARG app_version
 ENV APP_VERSION=$app_version
-
-# Dependencies for caching
-WORKDIR /opt/app
-COPY feedfarer.cabal stack.yaml .
-RUN stack --resolver nightly-2025-06-16 build \
-  --fast \
-  --only-dependencies \
-  --no-library-profiling \
-  --no-run-tests
-
-COPY . . 
-COPY /static /var/www/feedfarer-webui
 
 # Build and run tests
 CMD ["stack", "--resolver", "nightly-2025-06-16", "test", "--fast"]


### PR DESCRIPTION
Split dockerfiles into one more dockerfile so as to cache and push a base image featuring all ready-to-link dependencies.